### PR TITLE
bill.ts: improve display of additional information

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "declaration": true,
     "declarationDir": "./dist/types",
     "target": "es6",
+    "lib": ["es2019"],
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": false,


### PR DESCRIPTION
According to the SIX implementation guide, additional information can contain
both unstructured message and bill information.

They can be separated by a new line and the total length must be of 140 caracters.

To be able to keep track of the newY position I had to introduce a little hack
which split message on 40-length chunks.

PS: to be able to use `flatMap`, I had to add `es2019` in lib for the ts configuration.